### PR TITLE
Update to DFTK 0.7.6

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -21,8 +21,8 @@ Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 UnitfulAtomic = "a7773ee8-282e-5fa2-be4e-bd808c38a91a"
 
 [compat]
-AtomsBase = "0.3"
-DFTK = "0.6.20"
+AtomsBase = "0.5"
+DFTK = "0.7.3"
 DocStringExtensions = "0.9"
 HDF5 = "0.17"
 JLD2 = "0.4, 0.5"

--- a/Project.toml
+++ b/Project.toml
@@ -22,7 +22,7 @@ UnitfulAtomic = "a7773ee8-282e-5fa2-be4e-bd808c38a91a"
 
 [compat]
 AtomsBase = "0.5"
-DFTK = "0.7.3"
+DFTK = "0.7.6"
 DocStringExtensions = "0.9"
 HDF5 = "0.17"
 JLD2 = "0.4, 0.5"

--- a/precompilation_task.json
+++ b/precompilation_task.json
@@ -24,8 +24,7 @@
                     1.282887730510825,
                     1.282887730510825,
                     1.282887730510825
-                ],
-                "pseudopotential": "hgh/lda/si-q4"
+                ]
             },
             {
                 "symbol": "Si",
@@ -33,10 +32,12 @@
                     -1.282887730510825,
                     -1.282887730510825,
                     -1.282887730510825
-                ],
-                "pseudopotential": "hgh/lda/si-q4"
+                ]
             }
         ]
+    },
+    "pseudopotentials": {
+        "Si": "hgh/lda/si-q4"
     },
     "model_kwargs": {
         "functionals": [

--- a/src/AiidaDFTK.jl
+++ b/src/AiidaDFTK.jl
@@ -45,17 +45,16 @@ function build_system(data)
     periodic_system(atoms, bounding_box)
 end
 
-function build_pseudopotentials(data, system)
-    pseudopotentials::Dict{Symbol, <:Any} = Dict(data["pseudopotentials"])
-    kwargs = parse_kwargs(get(pseudopotentials, Symbol("\$kwargs"), Dict()))
-    delete!(pseudopotentials, Symbol("\$kwargs"))
-    # load_psp does not accept Dict{Symbol, Any}
-    family = Dict{Symbol, String}(pseudopotentials)
+function build_pseudopotentials(pseudo_data, system)
+    kwargs = parse_kwargs(get(pseudo_data, Symbol("\$kwargs"), Dict()))
+    family = Dict{Symbol, String}(k => pseudo_data[k]
+                                  for k in keys(pseudo_data)
+                                  if k != Symbol("\$kwargs"))
     load_psp(family, system; kwargs...)
 end
 
 function build_basis(data, system)
-    pseudopotentials = build_pseudopotentials(data, system)
+    pseudopotentials = build_pseudopotentials(data["pseudopotentials"], system)
     parsed = DFTK.parse_system(system, pseudopotentials)
     model = model_DFT(parsed.lattice, parsed.atoms, parsed.positions;
                       parsed.magnetic_moments,

--- a/test/iron.json
+++ b/test/iron.json
@@ -25,13 +25,15 @@
                     0,
                     0
                 ],
-                "pseudopotential": "../Fe.upf",
-                "pseudopotential_kwargs": {
-                    "rcut": 10
-                },
                 "magnetic_moment": 4
             }
         ]
+    },
+    "pseudopotentials": {
+        "Fe": "../Fe.upf",
+        "$kwargs": {
+            "rcut": 10
+        }
     },
     "model_kwargs": {
         "functionals": [

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -75,6 +75,26 @@ using UnitfulAtomic
         test_approx_eq(res, system_iron)
     end
 
+
+    @testset "build_pseudopotentials silicon" begin
+        data = Dict(:Si => "hgh/lda/si-q4")
+        pseudos = AiidaDFTK.build_pseudopotentials(data, system_silicon)
+
+        @test length(pseudos) == 2
+        @test pseudos[1] == pseudos[2]
+        @test pseudos[1] isa PspHgh
+    end
+
+    @testset "build_pseudopotentials iron" begin
+        data = Dict(:Fe => "Fe.upf",
+                    Symbol("\$kwargs") => Dict("rcut" => 10))
+        pseudos = AiidaDFTK.build_pseudopotentials(data, system_iron)
+
+        @test length(pseudos) == 1
+        @test pseudos[1] isa PspUpf
+        @test pseudos[1].rcut == 10
+    end
+
     @testset "build_basis silicon" begin
         smearing = Dict("\$symbol" => "Smearing.MethfesselPaxton", "\$args" => [1])
         data = Dict(

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -77,8 +77,8 @@ using UnitfulAtomic
 
 
     @testset "build_pseudopotentials silicon" begin
-        data = Dict(:Si => "hgh/lda/si-q4")
-        pseudos = AiidaDFTK.build_pseudopotentials(data, system_silicon)
+        pseudo_data = Dict(:Si => "hgh/lda/si-q4")
+        pseudos = AiidaDFTK.build_pseudopotentials(pseudo_data, system_silicon)
 
         @test length(pseudos) == 2
         @test pseudos[1] == pseudos[2]
@@ -86,9 +86,9 @@ using UnitfulAtomic
     end
 
     @testset "build_pseudopotentials iron" begin
-        data = Dict(:Fe => "Fe.upf",
-                    Symbol("\$kwargs") => Dict("rcut" => 10))
-        pseudos = AiidaDFTK.build_pseudopotentials(data, system_iron)
+        pseudo_data = Dict(:Fe => "Fe.upf",
+                           Symbol("\$kwargs") => Dict("rcut" => 10))
+        pseudos = AiidaDFTK.build_pseudopotentials(pseudo_data, system_iron)
 
         @test length(pseudos) == 1
         @test pseudos[1] isa PspUpf

--- a/test/silicon_bands.json
+++ b/test/silicon_bands.json
@@ -24,8 +24,7 @@
                     1.282887730510825,
                     1.282887730510825,
                     1.282887730510825
-                ],
-                "pseudopotential": "hgh/lda/si-q4"
+                ]
             },
             {
                 "symbol": "Si",
@@ -33,10 +32,12 @@
                     -1.282887730510825,
                     -1.282887730510825,
                     -1.282887730510825
-                ],
-                "pseudopotential": "hgh/lda/si-q4"
+                ]
             }
         ]
+    },
+    "pseudopotentials": {
+        "Si": "hgh/lda/si-q4"
     },
     "model_kwargs": {
         "functionals": [


### PR DESCRIPTION
The main change is the new pseudopotential format. Pseudos are now passed in a top-level object:
```json5
{
  "pseudopotentials": {
    "X": "pseudo_X.upf",
    "Y": "pseudo_Y.upf",
    "$kwargs": {
      // Can be used to pass extra kwargs (optional)
    }
  }
}
```
